### PR TITLE
Restricts argocd dependencies to bootstrap modules

### DIFF
--- a/module.yaml
+++ b/module.yaml
@@ -13,11 +13,9 @@ versions:
           version: ">= 1.1.0"
     - id: argocd
       refs:
-        - source: github.com/cloud-native-toolkit/terraform-tools-openshift-gitops.git
-          version: ">= 1.0.0"
-        - source: github.com/cloud-native-toolkit/terraform-tools-argocd.git
-          version: ">= 1.0.0"
         - source: github.com/cloud-native-toolkit/terraform-tools-argocd-bootstrap.git
+          version: ">= 1.0.0"
+        - source: github.com/cloud-native-toolkit/terraform-vsi-argocd-bootstrap.git
           version: ">= 1.0.0"
       optional: true
   variables:


### PR DESCRIPTION
Signed-off-by: Sean Sundberg <seansund@us.ibm.com>